### PR TITLE
Arduino v3.x.x support

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -914,6 +914,9 @@ void AsyncClient::_sockPoll(void)
 
     _notifyWrittenBuffers(notifylist, sent_errno);
 
+    /* Connection migh be closed after ACK notification. */
+    if (!connected()) return;
+
     uint32_t now = millis();
 
     // ACK Timeout - simulated by write queue staleness

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -351,7 +351,7 @@ bool AsyncClient::getNoDelay(){
     if (_socket == -1) return false;
 
     int flag = 0;
-    size_t size = sizeof(int);
+    socklen_t size = sizeof(int);
     int res = getsockopt(_socket, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, &size);
     if(res < 0) {
         log_e("fail on fd %d, errno: %d, \"%s\"", _socket, errno, strerror(errno));

--- a/src/AsyncTCP_TLS_Context.cpp
+++ b/src/AsyncTCP_TLS_Context.cpp
@@ -196,7 +196,11 @@ int AsyncTCP_TLS_Context::_startSSLClient(int sck, const char * host_or_ip,
         }
 
         log_v("Loading private key");
+#if MBEDTLS_VERSION_NUMBER < 0x03000000
         ret = mbedtls_pk_parse_key(&client_key, cli_key, cli_key_len, NULL, 0);
+#else
+        ret = mbedtls_pk_parse_key(&client_key, cli_key, cli_key_len, NULL, 0, mbedtls_ctr_drbg_random, &drbg_ctx);
+#endif
         _have_client_key = true;
 
         if (ret != 0) {

--- a/src/AsyncTCP_TLS_Context.h
+++ b/src/AsyncTCP_TLS_Context.h
@@ -2,8 +2,13 @@
 
 #if ASYNC_TCP_SSL_ENABLED
 
+#include "mbedtls/version.h"
 #include "mbedtls/platform.h"
+#if MBEDTLS_VERSION_NUMBER < 0x03000000
 #include "mbedtls/net.h"
+#else
+#include "mbedtls/net_sockets.h"
+#endif
 #include "mbedtls/debug.h"
 #include "mbedtls/ssl.h"
 #include "mbedtls/entropy.h"


### PR DESCRIPTION
Add support for Arduino 3.x.x, verified with https://github.com/pioarduino/platform-espressif32/releases/tag/51.03.05
Compatibility with Arduino 2.x.x is kept.